### PR TITLE
De-dupe via uniq

### DIFF
--- a/lib/grape-route-helpers/all_routes.rb
+++ b/lib/grape-route-helpers/all_routes.rb
@@ -11,9 +11,8 @@ module GrapeRouteHelpers
     def all_routes
       routes = subclasses.flat_map { |s| s.send(:prepare_routes) }
       # delete duplicate routes
-      routes.delete_if do |route|
-        all_options = routes.map { |r| r.instance_variable_get(:@options) }
-        all_options.count(route.instance_variable_get(:@options)) > 1
+      routes.uniq do |route|
+        route.instance_variable_get( :@options )
       end
     end
   end

--- a/spec/grape_route_helpers/all_routes_spec.rb
+++ b/spec/grape_route_helpers/all_routes_spec.rb
@@ -20,7 +20,8 @@ describe GrapeRouteHelpers::AllRoutes do
         end
 
         expect(duplicates).to be_empty
-        expect(all_route_options.size).to eq(6)
+        expect(all_route_options.size).to eq(7)
+
       end
     end
   end

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -43,6 +43,7 @@ module Spec
     # API with another API mounted inside it
     class MountedAPI < Grape::API
       mount Spec::Support::API
+      mount Spec::Support::APIWithMultipleVersions
     end
 
     # API with a version that would be illegal as a method name


### PR DESCRIPTION
Ruby 2.3.0 no longer mutates arrays when iterating so the delete_if approach no longer works. This quick fix changes just the de-duping to use uniq instead.
