### PR TITLE
Really remove duplicates

### DIFF
--- a/lib/grape-route-helpers/all_routes.rb
+++ b/lib/grape-route-helpers/all_routes.rb
@@ -11,9 +11,8 @@ module GrapeRouteHelpers
     def all_routes
       routes = subclasses.flat_map { |s| s.send(:prepare_routes) }
       # delete duplicate routes
-      routes.delete_if do |route|
-        all_options = routes.map { |r| r.instance_variable_get(:@options) }
-        all_options.count(route.instance_variable_get(:@options)) > 1
+      routes.uniq do |route|
+        route.instance_variable_get(:@options)
       end
     end
   end

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -14,6 +14,10 @@ module Spec
         'pong'
       end
 
+      get 'ping' do
+        'pong'
+      end
+
       resource :cats do
         get '/' do
           %w(cats cats cats)


### PR DESCRIPTION
If you really have duplicates in your api `delete_if` function does not really work, at least with ruby 2.3.0. Do not know if it is an issue in the earlier versions. Using `uniq` method ensures the correct behaviour.
