### PR TITLE
Allow multiple posts with different paths in a resource

### DIFF
--- a/lib/grape-route-helpers/all_routes.rb
+++ b/lib/grape-route-helpers/all_routes.rb
@@ -10,7 +10,13 @@ module GrapeRouteHelpers
 
     def all_routes
       routes = subclasses.flat_map { |s| s.send(:prepare_routes) }
-      routes.uniq(&:options)
+      routes.uniq do |r|
+        if r.path.nil?
+          [r.options]
+        else
+          [r.options, r.path]
+        end
+      end
     end
   end
 end

--- a/spec/grape_route_helpers/all_routes_spec.rb
+++ b/spec/grape_route_helpers/all_routes_spec.rb
@@ -12,7 +12,7 @@ describe GrapeRouteHelpers::AllRoutes do
 
         # A route is unique if no other route shares the same set of options
         all_route_options = Grape::API.all_routes.map do |r|
-          r.instance_variable_get(:@options)
+          r.instance_variable_get(:@options).merge(path: r.path)
         end
 
         duplicates = all_route_options.select do |o|
@@ -20,7 +20,7 @@ describe GrapeRouteHelpers::AllRoutes do
         end
 
         expect(duplicates).to be_empty
-        expect(all_route_options.size).to eq(7)
+        expect(all_route_options.size).to eq(9)
       end
     end
   end

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -57,7 +57,7 @@ module Spec
 
     # API with multiple posts in the same resource
     class APIWithMultiplePosts < Grape::API
-      resource :hamlit do
+      resource :hamlet do
         post :tobe do
           "to be"
         end

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -54,5 +54,18 @@ module Spec
         'pong'
       end
     end
+
+    # API with multiple posts in the same resource
+    class APIWithMultiplePosts < Grape::API
+      resource :hamlit do
+        post :tobe do
+          "to be"
+        end
+
+        post :ornot do
+          "or not"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The path prefix, suffix doesn't seem to be part of the options hash in grape routes only the namespace which does not allow for multiple post routes.
