### PR TITLE
Do not shadow helpers with same method but more params

### DIFF
--- a/lib/grape-route-helpers/all_routes.rb
+++ b/lib/grape-route-helpers/all_routes.rb
@@ -5,7 +5,9 @@ module GrapeRouteHelpers
   module AllRoutes
     def decorated_routes
       # memoize so that construction of decorated routes happens once
-      @decorated_routes ||= all_routes.map { |r| DecoratedRoute.new(r) }
+      @decorated_routes ||= all_routes
+                            .map { |r| DecoratedRoute.new(r) }
+                            .sort_by { |r| -r.dynamic_path_segments.count }
     end
 
     def all_routes

--- a/spec/grape_route_helpers/named_route_matcher_spec.rb
+++ b/spec/grape_route_helpers/named_route_matcher_spec.rb
@@ -148,6 +148,14 @@ describe GrapeRouteHelpers::NamedRouteMatcher do
         index_path = api_v1_cats_path
         expect(index_path).to eq('/api/v1/cats.json')
       end
+
+      it 'does not get shadowed by another route with less segments' do
+        show_path = api_v1_cats_owners_path('id' => 1)
+        expect(show_path).to eq('/api/v1/cats/1/owners.json')
+
+        show_path = api_v1_cats_owners_path('id' => 1, 'owner_id' => 1)
+        expect(show_path).to eq('/api/v1/cats/1/owners/1.json')
+      end
     end
 
     context 'when query params are passed in' do

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -24,6 +24,14 @@ module Spec
             'cat'
           end
         end
+
+        get ':id/owners' do
+          %w(owner1 owner2)
+        end
+
+        get ':id/owners/:owner_id' do
+          'owner'
+        end
       end
 
       route :any, '*path' do


### PR DESCRIPTION
When two helper methods are the same, but have different arguments (for example: `api_v1_cats_owners_path(id: 1)` vs `api_v1_cats_owners_path(id: 1, owner_id: 2)`) if the helper method with the least number of arguments is defined first (because the route was defined first) then it will shadow the longer route.

Example:
Consider the following routes:
```
      resource :cats do
        get '/' do
          %w(cats cats cats)
        end

        route_param :id do
          get do
            'cat'
          end
        end

        get ':id/owners' do
          %w(owner1 owner2)
        end

        get ':id/owners/:owner_id' do
          'owner'
        end
      end
```
The helper methods return:
```
api_v1_cats_owners_path(id: 1) #=> '/api/v1/cats/1/owners.json'
api_v1_cats_owners_path(id: 1, owner_id: 2) #=> '/api/v1/cats/1/owners.json'
```
which is wrong. `api_v1_cats_owners_path(id: 1, owner_id: 2)` should return `'/api/v1/cats/1/owners/2.json'`

This PR fixes this issue in the simplest possible way: when `GrapeRouteHelpers::AllRoutes` is generating `@decorated_routes`, it sorts the routes in descending order by the count of `dynamic_path_segments` it has.

Fixes #22 